### PR TITLE
Proof of concept for account profiles.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function Account (options) {
     update: require('./lib/update').bind(null, state),
     profile: {
       get: require('./lib/profile-get').bind(null, state),
-      fetch: require('./lib/profile-fetch').bind(null, state, 'account.profile'),
+      fetch: require('./lib/profile-fetch').bind(null, state),
       update: require('./lib/profile-update').bind(null, state)
     },
     request: require('./lib/request').bind(null, state),

--- a/lib/sign-in.js
+++ b/lib/sign-in.js
@@ -38,7 +38,7 @@ function signIn (state, options) {
 
   .then(function (response) {
     var data = internals.deserialise(response.body, {
-      include: 'account'
+      include: 'account.profile'
     })
 
     // admins don’t have an account
@@ -56,6 +56,7 @@ function signIn (state, options) {
 
     state.account = {
       username: data.account.username,
+      profile: data.account.profile || {},
       session: {
         id: data.id
       }

--- a/lib/sign-up.js
+++ b/lib/sign-up.js
@@ -19,10 +19,6 @@ function signUp (state, options) {
     return Promise.reject(error)
   }
 
-  if (options.profile) {
-    return Promise.reject(new Error('SignUp with profile data not yet implemented. Please see https://github.com/hoodiehq/hoodie-account-client/issues/11.'))
-  }
-
   return internals.request({
     url: state.url + '/session/account',
     method: 'PUT',


### PR DESCRIPTION
Some notes on this PR:
- Tests have not yet been completed.
- I have assumed that profiles will be a permanent part of all account requests. I.e. this information is always included in get requests.
- Have only focussed on initial sign-up and session/account retrieval. So currently no `profile` requests have been dealt to.

To do:
- [ ] Code tests
- [ ] Profile requests (fetch, update)
- [ ] Consider if the profile object is an optional piece of information
- [ ] More in-context/real-life testing
- [ ] PR `hoodie-account`

More than happy for someone to add to this PR ;)