### PR TITLE
account.profile.get() should fallback to {} when signed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,7 +668,8 @@ account.profile.get(properties)
   </tr>
 </table>
 
-Returns object with profile properties, or `undefined` if not signed in.
+Returns object with profile properties, falls back to empty object `{}`.
+Returns `undefined` if not signed in.
 
 Examples
 
@@ -1043,7 +1044,7 @@ npm link /path/to/hoodie-account-client
 npm start
 ```
 
-hoodie-account bundles hoodie-account-client on `npm start`, so you need to restart hoodie-account to see your changes. 
+hoodie-account bundles hoodie-account-client on `npm start`, so you need to restart hoodie-account to see your changes.
 
 ## Contributing
 

--- a/lib/profile-get.js
+++ b/lib/profile-get.js
@@ -7,5 +7,5 @@ internals.getProperties = require('../utils/get-properties')
 
 function profileGet (state, path) {
   var profile = get(state, 'account.profile')
-  return internals.getProperties(profile, path)
+  return internals.getProperties(profile, path) || {}
 }

--- a/lib/profile-get.js
+++ b/lib/profile-get.js
@@ -4,8 +4,12 @@ var get = require('lodash/get')
 
 var internals = module.exports.internals = {}
 internals.getProperties = require('../utils/get-properties')
+internals.isSignedIn = require('./is-signed-in')
 
 function profileGet (state, path) {
+  if (!internals.isSignedIn(state)) {
+    return undefined
+  }
   var profile = get(state, 'account.profile')
   return internals.getProperties(profile, path) || {}
 }

--- a/test/integration/update-profile-test.js
+++ b/test/integration/update-profile-test.js
@@ -18,7 +18,7 @@ var options = {
 test('sign in and change username', function (t) {
   store.clear()
 
-  t.plan(4)
+  t.plan(5)
 
   var account = new Account({
     url: baseURL,
@@ -50,6 +50,11 @@ test('sign in and change username', function (t) {
 
   .then(function (profileProperties) {
     t.is(profileProperties.fullName, 'Docs Chicken', 'profile.update() resolves with profile properties')
+  })
+
+  .then(function () {
+    var profileProperties = account.profile.get()
+    t.is(profileProperties.fullName, 'Docs Chicken', 'profile.get() returns profile properties')
   })
 
   .catch(t.error)

--- a/test/unit/profile-get-test.js
+++ b/test/unit/profile-get-test.js
@@ -21,3 +21,19 @@ test('profileGet', function (t) {
   simple.restore()
   t.end()
 })
+
+test('profileGet with empty profile', function (t) {
+  simple.mock(internals, 'getProperties').returnWith(undefined)
+  var result = get({
+    account: {}
+  })
+
+  t.deepEqual(internals.getProperties.lastCall.args, [
+    undefined,
+    undefined
+  ], 'calls utils.getProperties with "profile" basepath')
+  t.same(result, {}, 'returns result of fetchProperties')
+
+  simple.restore()
+  t.end()
+})

--- a/test/unit/profile-get-test.js
+++ b/test/unit/profile-get-test.js
@@ -6,6 +6,7 @@ var internals = get.internals
 
 test('profileGet', function (t) {
   simple.mock(internals, 'getProperties').returnWith('foo')
+  simple.mock(internals, 'isSignedIn').returnWith(true)
   var result = get({
     account: {
       profile: 'profile'
@@ -16,7 +17,7 @@ test('profileGet', function (t) {
     'profile',
     'path'
   ], 'calls utils.getProperties with "profile" basepath')
-  t.is(result, 'foo', 'returns result of fetchProperties')
+  t.is(result, 'foo', 'returns result of getProperties')
 
   simple.restore()
   t.end()
@@ -24,6 +25,7 @@ test('profileGet', function (t) {
 
 test('profileGet with empty profile', function (t) {
   simple.mock(internals, 'getProperties').returnWith(undefined)
+  simple.mock(internals, 'isSignedIn').returnWith(true)
   var result = get({
     account: {}
   })
@@ -32,8 +34,18 @@ test('profileGet with empty profile', function (t) {
     undefined,
     undefined
   ], 'calls utils.getProperties with "profile" basepath')
-  t.same(result, {}, 'returns result of fetchProperties')
+  t.same(result, {}, 'returns result of getProperties')
 
   simple.restore()
+  t.end()
+})
+
+test('profileGet when signed out', function (t) {
+  simple.mock(internals, 'isSignedIn').returnWith(false)
+  var result = get('internal state')
+
+  t.deepEqual(internals.isSignedIn.lastCall.args, ['internal state'], 'calls utils.isSignedIn with internal state')
+  t.same(result, undefined, 'returns undefined')
+
   t.end()
 })


### PR DESCRIPTION
closes #105