### PR TITLE
test: admin.signOut() throws error when signed out

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -206,6 +206,10 @@ Rejects with:
 
 <table>
   <tr>
+    <th align="left"><code>UnauthenticatedError</code></th>
+    <td>Not signed in</td>
+  </tr>
+  <tr>
     <th align="left"><code>Error</code></th>
     <td><em>A custom error thrown in a <code>before:signout</code> hook</em></td>
   </tr>

--- a/lib/sign-out.js
+++ b/lib/sign-out.js
@@ -7,8 +7,13 @@ var internals = module.exports.internals = {}
 internals.request = require('../utils/request')
 internals.clearSession = require('../utils/clear-session')
 internals.get = require('./get')
+internals.isSignedIn = require('./is-signed-in')
 
 function signOut (state) {
+  if (!internals.isSignedIn(state)) {
+    return Promise.reject(new Error('UnauthenticatedError: Not signed in'))
+  }
+
   var accountProperties = internals.get(state)
 
   var preHooks = []

--- a/test/integration/sign-out-not-signed-in-test.js
+++ b/test/integration/sign-out-not-signed-in-test.js
@@ -1,0 +1,28 @@
+var store = require('humble-localstorage')
+var test = require('tape')
+
+var Account = require('../../index')
+
+var baseURL = 'http://localhost:3000'
+
+test('sign out without being signed in', function (t) {
+  t.plan(2)
+
+  // simulate user who has not yet signed in
+  store.clear()
+  store.setObject('account', {})
+
+  var account = new Account({
+    url: baseURL,
+    id: 'abc4567'
+  })
+
+  account.signOut().catch(function (error) {
+    t.is(typeof error, 'object', 'rejects with error object')
+    t.equal(
+      error.message,
+      'UnauthenticatedError: Not signed in',
+      'error not an UnauthenticatedError'
+    )
+  })
+})

--- a/test/integration/sign-out-not-signed-in-test.js
+++ b/test/integration/sign-out-not-signed-in-test.js
@@ -10,11 +10,9 @@ test('sign out without being signed in', function (t) {
 
   // simulate user who has not yet signed in
   store.clear()
-  store.setObject('account', {})
 
   var account = new Account({
-    url: baseURL,
-    id: 'abc4567'
+    url: baseURL
   })
 
   account.signOut().catch(function (error) {

--- a/test/unit/sign-out-test.js
+++ b/test/unit/sign-out-test.js
@@ -68,3 +68,25 @@ test('signOut() with request error', function (t) {
     t.pass('rejects with error')
   })
 })
+
+test('signOut() without being signed in', function (t) {
+  t.plan(2)
+
+  signOut({
+    account: {},
+    emitter: {
+      emit: simple.stub()
+    }
+  })
+
+  .then(t.fail.bind(t, 'must reject'))
+
+  .catch(function (error) {
+    t.is(typeof error, 'object', 'rejects with error object')
+    t.equal(
+      error.message,
+      'UnauthenticatedError: Not signed in',
+      'error not an UnauthenticatedError'
+    )
+  })
+})


### PR DESCRIPTION
admin.signOut() throws `TypeError: Cannot read property 'session' of null` when a user is not signed in.  This commit contains documentation and failing unit/integration test updates in order to catch the condition where a user has attempted to sign out without being signed in and, rather than throwing the current error, throw an `UnauthenticatedError: Not signed in` error, instead.

closes hoodiehq/camp#12