### PR TITLE
92/store created at

### DIFF
--- a/lib/sign-up.js
+++ b/lib/sign-up.js
@@ -23,6 +23,8 @@ function signUp (state, options) {
     return Promise.reject(new Error('SignUp with profile data not yet implemented. Please see https://github.com/hoodiehq/hoodie-account-client/issues/11.'))
   }
 
+  options.createdAt = get(state, 'account.createdAt')
+
   return internals.request({
     url: state.url + '/session/account',
     method: 'PUT',

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "greenkeeper-postpublish": "^1.0.0",
     "istanbul": "^0.3.19",
     "istanbul-coveralls": "^1.0.3",
+    "lolex": "^1.5.1",
     "mkdirp": "^0.5.1",
     "nock": "^7.2.2",
     "npm-run-all": "^1.3.2",

--- a/test/unit/sign-up-test.js
+++ b/test/unit/sign-up-test.js
@@ -1,5 +1,6 @@
 var simple = require('simple-mock')
 var test = require('tape')
+var lolex = require('lolex')
 
 var signUp = require('../../lib/sign-up')
 
@@ -34,12 +35,14 @@ test('signUp without username', function (t) {
 test('signUp with username & password', function (t) {
   t.plan(6)
 
+  var clock = lolex.install(0)
   var state = {
     url: 'http://example.com',
     validate: simple.stub(),
     emitter: {
       emit: simple.stub()
-    }
+    },
+    account: {createdAt: new Date().toISOString()}
   }
 
   simple.mock(signUp.internals, 'request').resolveWith({
@@ -59,13 +62,15 @@ test('signUp with username & password', function (t) {
   .then(function (result) {
     t.deepEqual(state.validate.lastCall.arg, {
       username: 'pat',
-      password: 'secret'
+      password: 'secret',
+      createdAt: '1970-01-01T00:00:00.000Z'
     }, 'passes username & password to validate')
     t.deepEqual(signUp.internals.serialise.lastCall.args, [
       'account',
       {
         username: 'pat',
-        password: 'secret'
+        password: 'secret',
+        createdAt: '1970-01-01T00:00:00.000Z'
       },
       undefined // state.account.id, from `new Account({id: ...})`
     ], 'passes username & password to serialise')
@@ -82,6 +87,7 @@ test('signUp with username & password', function (t) {
     t.is(result.id, 'deserialise id', 'resolves with account id')
     t.is(result.username, 'deserialise username', 'resolves with account username')
 
+    clock.uninstall()
     simple.restore()
   })
   .catch(t.error)

--- a/utils/get-state.js
+++ b/utils/get-state.js
@@ -40,7 +40,8 @@ function getState (options) {
 
   if (!state.account) {
     state.account = {
-      id: options.id || generateId()
+      id: options.id || generateId(),
+      createdAt: new Date().toISOString()
     }
 
     saveAccount({


### PR DESCRIPTION
Not sure exactly where createdAt should be implemented in the account-client. I'm still working on understanding the architecture. During `account.signUp(options)` should `options` object already have a property `createdAt`? If so where is this `options` object being passed in from?

Maybe my whole approach might be wrong, feedback is much appreciated :)