### PR TITLE
Unset `session.invalid` after fetching account from remote

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -40,6 +40,12 @@ function accountGet (state, path, options) {
         cachedProperties = result
       }
 
+      // reauthenticate an expired session
+      if (cachedProperties.session.invalid) {
+        delete cachedProperties.session.invalid
+        state.emitter.emit('reauthenticate')
+      }
+
       return state.cache.set(cachedProperties)
 
       .then(function () {

--- a/lib/profile-get.js
+++ b/lib/profile-get.js
@@ -38,6 +38,12 @@ function profileGet (state, path, options) {
         cachedProperties.profile = result
       }
 
+      // reauthenticate an expired session
+      if (cachedProperties.session.invalid) {
+        delete cachedProperties.session.invalid
+        state.emitter.emit('reauthenticate')
+      }
+
       return state.cache.set(cachedProperties)
 
       .then(function () {


### PR DESCRIPTION
Fixes #146 

Notify : @gr2m 