### PR TITLE
154/prevent signin when signed in

### DIFF
--- a/lib/sign-in.js
+++ b/lib/sign-in.js
@@ -24,6 +24,11 @@ function signIn (state, options) {
   })
 
   .then(function (cache) {
+    // If a different user is signed in than the one trying to signIn, throw an error
+    if (cache.session && cache.username !== options.username) {
+      return Promise.reject(new Error('You must sign out before signing in'))
+    }
+
     return state.hook('signin', options, function (options) {
       return internals.request({
         url: state.url + '/session',

--- a/test/integration/sign-in-test.js
+++ b/test/integration/sign-in-test.js
@@ -88,7 +88,7 @@ test('sign in', function (t) {
 
 test('sign in while signed in fails', function (t) {
   store.clear()
-  t.plan(2)
+  t.plan(1)
 
   var account = new Account({
     url: baseURL,
@@ -102,8 +102,6 @@ test('sign in while signed in fails', function (t) {
   account.signIn(options)
 
   .then(function (signInResult) {
-    t.pass('signs in')
-
     return account.signIn({
       username: 'fox@docs.com',
       password: 'secret'

--- a/test/integration/sign-in-test.js
+++ b/test/integration/sign-in-test.js
@@ -62,7 +62,7 @@ test('sign in', function (t) {
   })
 
   .then(function (signOutResult) {
-    t.pass('signes out')
+    t.pass('signs out')
 
     t.is(signOutResult.username, 'chicken@docs.com')
 

--- a/test/integration/sign-in-test.js
+++ b/test/integration/sign-in-test.js
@@ -33,7 +33,7 @@ test('sign in', function (t) {
   account.signIn(options)
 
   .then(function (signInResult) {
-    t.pass('signes in')
+    t.pass('signs in')
     t.is(signInResult.username, 'chicken@docs.com')
 
     var storeAccount = store.getObject('account')

--- a/test/integration/sign-in-test.js
+++ b/test/integration/sign-in-test.js
@@ -86,7 +86,7 @@ test('sign in', function (t) {
   .catch(t.error)
 })
 
-test('sign in while signed in fails', function (t) {
+test('prevent sign-in when already signed in', function (t) {
   store.clear()
   t.plan(1)
 

--- a/test/integration/sign-in-test.js
+++ b/test/integration/sign-in-test.js
@@ -85,3 +85,36 @@ test('sign in', function (t) {
 
   .catch(t.error)
 })
+
+test('sign in while signed in fails', function (t) {
+  store.clear()
+  t.plan(2)
+
+  var account = new Account({
+    url: baseURL,
+    id: 'abc4567'
+  })
+
+  nock(baseURL)
+    .put('/session')
+    .reply(201, signInResponse)
+
+  account.signIn(options)
+
+  .then(function (signInResult) {
+    t.pass('signs in')
+
+    return account.signIn({
+      username: 'fox@docs.com',
+      password: 'secret'
+    })
+  })
+
+  .then(function () {
+    t.fail('Sign in must fail when already signed in')
+  })
+
+  .catch(function (error) {
+    t.is(error.message, 'You must sign out before signing in')
+  })
+})


### PR DESCRIPTION
Closes #154 by checking on signIn whether a session exists, and whether that session belongs to anyone but the user trying to sign in. :no_good_man: 

Oh, I didn’t touch `signUp` for now, although it’s mentioned in the issue. 

Ready for review @hoodiehq/maintainers !